### PR TITLE
add flattr meta tag to verify domain ownership

### DIFF
--- a/_includes/head/flattr.html
+++ b/_includes/head/flattr.html
@@ -1,0 +1,1 @@
+<meta name="flattr:id" content="m05226">

--- a/_includes/head/head.html
+++ b/_includes/head/head.html
@@ -27,4 +27,6 @@
   {% endunless %}
 
   {% include head/indie-auth.html %}
+  
+  {% include head/flattr.html %}
 </head>


### PR DESCRIPTION
Required for verifying domain ownership:

> One or more of your websites could not be verified. Please make sure the following meta tag is present in the `<head>` section (on all pages) and try again.
>
> ```html
> <meta name="flattr:id" content="m05226">
> ```