### PR TITLE
update legacy UA analytics to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ repository: 0xdevalias/devalias.net
 #   alexa: 1234
 #   yandex: 1234
 
-google_analytics: UA-27970144-1
+google_analytics: G-3FW5B1CS26
 disqus_shortname: devalias
 
 # Front Matter defaults (http://jekyllrb.com/docs/configuration/#front-matter-defaults)

--- a/_includes/head/head.html
+++ b/_includes/head/head.html
@@ -19,6 +19,8 @@
   <!-- <meta name="twitter:image" content="{{ site.baseurl | chomp_slash }}{{ site.default_cover }}" /> -->
   <!-- /end tags -->
 
+  {% include scripts/analytics.html %}
+
   {% include head/styles.html %}
   {% include head/fontawesome.html %}
 

--- a/_includes/scripts/analytics.html
+++ b/_includes/scripts/analytics.html
@@ -1,10 +1,9 @@
-    <!-- Google Analytics Tracking code -->
-     <script>
-	    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-	    ga('create', '{{ site.google_analytics }}', 'auto');
-	    ga('send', 'pageview');
-     </script>
+      gtag('config', '{{ site.google_analytics }}');
+    </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,6 @@
     <script type="text/javascript" src="{{ site.baseurl | chomp_slash }}/assets/js/jquery.fitvids.js"></script>
     <script type="text/javascript" src="{{ site.baseurl | chomp_slash }}/assets/js/index.js"></script>
 
-    {% include scripts/analytics.html %}
     {% unless site.webmentions.disabled %}
         {% include scripts/webmention.html %}
     {% endunless %}


### PR DESCRIPTION
- fixes https://github.com/0xdevalias/devalias.net/issues/109

See the following comment for deepdive steps into getting a local setup running/building/deploying:

- https://github.com/0xdevalias/devalias.net/issues/27#issuecomment-2179768321

Following those instructions, we got a deploy to work:

- https://github.com/0xdevalias/devalias.net/commit/4ffa1d7bc38e6627e7fda92223182468068f804e

Which we can see the deploy run for here:

- https://github.com/0xdevalias/devalias.net/actions/runs/9593900561
- https://github.com/0xdevalias/devalias.net/actions/runs/9593900561/job/26455334256

Once we do a few manual checks on the site to ensure this deployed correctly, we can merge this PR.