### PR TITLE
disable/remove jekyll related posts (--lsi) + related dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ gem 'jekyll','~>4.1.0'
 #   https://github.com/0xdevalias/devalias.net/issues/83
 #   https://github.com/jekyll/classifier-reborn/issues/192
 #   https://github.com/SciRuby/rb-gsl/issues/63
-gem 'nmatrix'
-gem 'gsl' # Note: you need to install a compatible version (eg. 2.1) of gsl first: brew install gsl@2.1
-gem 'classifier-reborn'
+# gem 'nmatrix'
+# gem 'gsl' # Note: you need to install a compatible version (eg. 2.1) of gsl first: brew install gsl@2.1
+# gem 'classifier-reborn'
 
 group :jekyll_plugins do
   # gem 'jekyll-admin' # using outdated 1.4.x version of sinatra, see https://github.com/jekyll/jekyll-admin/issues/601

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,6 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    backports (3.18.1)
-    classifier-reborn (2.2.0)
-      fast-stemmer (~> 1.0)
     colorator (1.1.0)
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
@@ -16,10 +13,8 @@ GEM
     eventmachine (1.2.7)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    fast-stemmer (1.0.2)
     ffi (1.13.1)
     forwardable-extended (2.6.0)
-    gsl (2.1.0.3)
     http_parser.rb (0.6.0)
     i18n (1.8.4)
       concurrent-ruby (~> 1.0)
@@ -78,13 +73,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     multipart-post (2.1.1)
-    nmatrix (0.2.4)
-      packable (~> 1.3, >= 1.3.5)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    packable (1.3.14)
-      backports
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.5)
@@ -109,8 +100,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  classifier-reborn
-  gsl
   jekyll (~> 4.1.0)
   jekyll-commonmark
   jekyll-compose
@@ -126,7 +115,6 @@ DEPENDENCIES
   jekyll-time-to-read
   jekyll-twitter-plugin
   jekyll_version_plugin
-  nmatrix
 
 BUNDLED WITH
    2.1.4

--- a/bin/build
+++ b/bin/build
@@ -60,4 +60,5 @@ if ! check_site_setup; then
 fi
 
 # Build the Jekyll site
-JEKYLL_ENV=production bundle exec jekyll build --lsi --profile $@
+# JEKYLL_ENV=production bundle exec jekyll build --lsi --profile $@
+JEKYLL_ENV=production bundle exec jekyll build --profile $@


### PR DESCRIPTION
This PR comments out the flags/dependencies related to Jekyll's 'related posts' feature, and specifically the `--lsi` 'Latent Semantic Indexing' feature for calculating related posts based on similarity.

It was pointed out that we're not even currently making uses of the related posts functionality, so the complexities of trying to get the dependencies to speed up `--lsi` aren't even relevant to us currently:

> A few notes that you might find helpful:
> 
> - You're not noticing any difference in build times with the `--lsi` option because your site (as it is today in this repo) doesn't use related posts (so the `--lsi` option does nothing). To use LSI, you need to call `site.related_posts` somewhere in a Liquid template. For example, you might add something like the following to `_layouts/post.html`:
>   ```html
>   {% for post in site.related_posts limit:3 %}
>     <p>{{ post.title }}</p>
>   {% endfor %}
>   ```
> - When you call `site.related_posts`, if you don't pass the `--lsi` option, it's [just recent posts](https://jekyllrb.com/docs/variables/#site-variables).
> - If you are using `site.related_posts` and you pass the `--lsi` option, You'll see `Populating LSI...` in your `jekyll build --lsi` output. The build will be slow unless you have the gsl gem and native gsl library installed. I haven't experimented with nmatrix or narray at all, but simply using the gsl gem results in a ~500x speed increase for my use.
> 
> _Originally posted by @mkasberg in https://github.com/0xdevalias/devalias.net/issues/83#issuecomment-846468147_

That said, it would be nice to bring back some kind of 'related posts' feature at some point.. and there are some further notes about that in the following comment (both with using `--lsi` + more updated dependencies, or by using OpenAI embeddings/similar):

- https://github.com/0xdevalias/devalias.net/issues/87#issuecomment-2179847993

## See Also

This PR partially fixes/relates to the following:

- https://github.com/0xdevalias/devalias.net/issues/83
- https://github.com/0xdevalias/devalias.net/issues/87

And may have some impact on the following:

- https://github.com/0xdevalias/devalias.net/issues/27
  - https://github.com/0xdevalias/devalias.net/pull/86